### PR TITLE
[#6] Add generic functions

### DIFF
--- a/src/Slist.hs
+++ b/src/Slist.hs
@@ -1906,17 +1906,37 @@ insertBy f a Slist{..} = Slist (L.insertBy f a sList) (sSize + 1)
 -- Generic fuctions
 ----------------------------------------------------------------------------
 
--- | O(1)
--- The 'genericLength' function is an overloaded version of 'length'.  In
--- particular, instead of returning an 'Int', it returns any type which is
--- an instance of 'Num'.
+{- | @O(1)@.
+The 'genericLength' function is an overloaded version of 'length'.
+In particular, instead of returning an 'Int', it returns any type which is an
+instance of 'Num'.
+
+>>> genericLength $ one 42
+1
+>>> genericLength $ slist [1..3]
+3
+>>> genericLength $ infiniteSlist [1..]
+9223372036854775807
+-}
 genericLength :: Num i => Slist a -> i
 genericLength = fromIntegral . length
 {-# INLINE genericLength #-}
 
--- | @O(i) | i < n@ and @O(1) | otherwise@.
--- The 'genericTake' function is an overloaded version of 'take', which
--- accepts any 'Integral' value as the number of elements to take.
+{- | @O(i) | i < n@ and @O(1) | otherwise@.
+The 'genericTake' function is an overloaded version of 'take', which
+accepts any 'Integral' value as the number of elements to take.
+
+>>> genericTake 5 $ slist "Hello world!"
+Slist {sList = "Hello", sSize = Size 5}
+>>> genericTake 20 $ slist "small"
+Slist {sList = "small", sSize = Size 5}
+>>> genericTake 0 $ slist "none"
+Slist {sList = "", sSize = Size 0}
+>>> genericTake (-11) $ slist "hmm"
+Slist {sList = "", sSize = Size 0}
+>>> genericTake 4 $ infiniteSlist [1..]
+Slist {sList = [1,2,3,4], sSize = Size 4}
+-}
 genericTake :: Integral i => i -> Slist a -> Slist a
 genericTake i sl@Slist{..}
     | Size i' >= sSize = sl
@@ -1928,9 +1948,25 @@ genericTake i sl@Slist{..}
     where i' = fromIntegral i
 {-# INLINE genericTake #-}
 
--- | @O(i) | i < n@ and @O(1) | otherwise@.
--- The 'genericDrop' function is an overloaded version of 'drop', which
--- accepts any 'Integral' value as the number of elements to drop.
+{- | @O(i) | i < n@ and @O(1) | otherwise@.
+The 'genericDrop' function is an overloaded version of 'drop', which accepts
+any 'Integral' value as the number of elements to drop.
+
+>>> genericDrop 6 $ slist "Hello World"
+Slist {sList = "World", sSize = Size 5}
+>>> genericDrop 42 $ slist "oops!"
+Slist {sList = "", sSize = Size 0}
+>>> genericDrop 0 $ slist "Hello World!"
+Slist {sList = "Hello World!", sSize = Size 12}
+>>> genericDrop (-4) $ one 42
+Slist {sList = [42], sSize = Size 1}
+
+@
+>> __drop 5 $ 'infiniteSlist' [1..]__
+Slist {sList = [6..], sSize = 'Infinity'}
+@
+
+-}
 genericDrop :: Integral i => i -> Slist a -> Slist a
 genericDrop i sl@Slist{..}
     | i <= 0 = sl
@@ -1942,9 +1978,25 @@ genericDrop i sl@Slist{..}
     where i' = fromIntegral i
 {-# INLINE genericDrop #-}
 
--- | @O(i) | i < n@ and @O(1) | otherwise@.
--- The 'genericSplitAt' function is an overloaded version of 'splitAt', which
--- accepts any 'Integral' value as the position at which to split.
+{- | @O(i) | i < n@ and @O(1) | otherwise@.
+The 'genericSplitAt' function is an overloaded version of 'splitAt', which
+accepts any 'Integral' value as the position at which to split.
+
+>>> genericSplitAt 5 $ slist "Hello World!"
+(Slist {sList = "Hello", sSize = Size 5},Slist {sList = " World!", sSize = Size 7})
+>>> genericSplitAt 0 $ slist "abc"
+(Slist {sList = "", sSize = Size 0},Slist {sList = "abc", sSize = Size 3})
+>>> genericSplitAt 4 $ slist "abc"
+(Slist {sList = "abc", sSize = Size 3},Slist {sList = "", sSize = Size 0})
+>>> genericSplitAt (-42) $ slist "??"
+(Slist {sList = "", sSize = Size 0},Slist {sList = "??", sSize = Size 2})
+
+@
+>> __genericSplitAt 2 $ 'infiniteSlist' [1..]__
+(Slist {sList = [1,2], sSize = 'Size' 2}, Slist {sList = [3..], sSize = 'Infinity'})
+@
+
+-}
 genericSplitAt :: Integral i => i -> Slist a -> (Slist a, Slist a)
 genericSplitAt i sl@Slist{..}
     | i <= 0 = (mempty, sl)
@@ -1957,7 +2009,21 @@ genericSplitAt i sl@Slist{..}
       i' = fromIntegral i
 {-# INLINE genericSplitAt #-}
 
--- TODO: Add doc
+{- | @O(i) | i < n@ and @O(1) | otherwise@.
+The 'genericAt' function is an overloaded version of 'at', which
+accepts any 'Integral' value as the position. If the element on the given
+position does not exist it will return 'Nothing'.
+
+>>> let sl = slist [1..10]
+>>> genericAt 0 sl
+Just 1
+>>> genericAt (-1) sl
+Nothing
+>>> genericAt 11 sl
+Nothing
+>>> genericAt 9 sl
+Just 10
+-}
 genericAt :: Integral i => i -> Slist a -> Maybe a
 genericAt n Slist{..}
     | n' < 0 || Size n' >= sSize = Nothing
@@ -1965,21 +2031,38 @@ genericAt n Slist{..}
     where n' = fromIntegral n
 {-# INLINE genericAt #-}
 
--- | @O(min i n)@
--- The 'genericUnsafeAt' function is an overloaded version of 'unsafeAt', which
--- accepts any 'Integral' value as the position. If the element on the given
--- position does not exist it throws the exception at run-time.
-genericUnsafeAt :: Integral i => Slist a -> i -> a
-genericUnsafeAt _ i | i < 0 = errorWithoutStackTrace "Slist.genericIndex: negative argument."
-genericUnsafeAt (Slist l Infinity) i = L.genericIndex l i
-genericUnsafeAt (Slist l (Size n)) i
-    | i >= fromIntegral n = errorWithoutStackTrace "Slist.genericIndex: index too large."
+{- | @O(min i n)@.
+The 'genericUnsafeAt' function is an overloaded version of 'unsafeAt', which
+accepts any 'Integral' value as the position. If the element on the given
+position does not exist it throws the exception at run-time.
+
+>>> let sl = slist [1..10]
+>>> genericUnsafeAt 0 sl
+1
+>>> genericUnsafeAt (-1) sl
+*** Exception: Slist.genericUnsafeAt: negative argument
+>>> genericUnsafeAt 11 sl
+*** Exception: Slist.genericUnsafeAt: index too large
+>>> genericUnsafeAt 9 sl
+10
+-}
+genericUnsafeAt :: Integral i => i -> Slist a -> a
+genericUnsafeAt i _ | i < 0 = errorWithoutStackTrace "Slist.genericUnsafeAt: negative argument"
+genericUnsafeAt i (Slist l Infinity) = L.genericIndex l i
+genericUnsafeAt i (Slist l (Size n))
+    | i >= fromIntegral n = errorWithoutStackTrace "Slist.genericUnsafeAt: index too large"
     | otherwise = L.genericIndex l i
 {-# INLINE genericUnsafeAt #-}
 
--- | @O(n)@
--- The 'genericReplicate' function is an overloaded version of 'replicate',
--- which accepts any 'Integral' value as the number of repetitions to make.
+{- | @O(n)@.
+The 'genericReplicate' function is an overloaded version of 'replicate',
+which accepts any 'Integral' value as the number of repetitions to make.
+
+>>> genericReplicate 3 'o'
+Slist {sList = "ooo", sSize = Size 3}
+>>> genericReplicate (-11) "hmm"
+Slist {sList = [], sSize = Size 0}
+-}
 genericReplicate :: Integral i => i -> a -> Slist a
 genericReplicate n x
     | n <= 0 = mempty

--- a/src/Slist.hs
+++ b/src/Slist.hs
@@ -1922,22 +1922,24 @@ genericTake i sl@Slist{..}
     | Size i' >= sSize = sl
     | i' <= 0 = mempty
     | otherwise = Slist
-        { sList = L.genericTake n sList
-        , sSize = min sSize (Size (fromIntegral n))
+        { sList = L.genericTake i sList
+        , sSize = min sSize (Size i')
         }
+    where i' = fromIntegral i
 {-# INLINE genericTake #-}
 
 -- | @O(i) | i < n@ and @O(1) | otherwise@.
 -- The 'genericDrop' function is an overloaded version of 'drop', which
 -- accepts any 'Integral' value as the number of elements to drop.
 genericDrop :: Integral i => i -> Slist a -> Slist a
-genericDrop n sl@Slist{..}
-    | n <= 0 = sl
-    | Size (fromIntegral n) >= sSize = mempty
+genericDrop i sl@Slist{..}
+    | i <= 0 = sl
+    | Size i' >= sSize = mempty
     | otherwise = Slist
-        { sList = L.genericDrop n sList
-        , sSize = sSize - Size (fromIntegral n)
+        { sList = L.genericDrop i sList
+        , sSize = sSize - Size i'
         }
+    where i' = fromIntegral i
 {-# INLINE genericDrop #-}
 
 -- | @O(i) | i < n@ and @O(1) | otherwise@.
@@ -1946,11 +1948,13 @@ genericDrop n sl@Slist{..}
 genericSplitAt :: Integral i => i -> Slist a -> (Slist a, Slist a)
 genericSplitAt i sl@Slist{..}
     | i <= 0 = (mempty, sl)
-    | Size (fromIntegral i) >= sSize = (sl, mempty)
+    | Size i' >= sSize = (sl, mempty)
     | otherwise =
       let (l1, l2) = L.genericSplitAt i sList
-          s2 = sSize - Size (fromIntegral i)
-      in (Slist l1 $ Size (fromIntegral i), Slist l2 s2)
+          s2 = sSize - Size i'
+      in (Slist l1 $ Size i', Slist l2 s2)
+    where
+      i' = fromIntegral i
 {-# INLINE genericSplitAt #-}
 
 -- TODO: Add doc

--- a/src/Slist.hs
+++ b/src/Slist.hs
@@ -1951,12 +1951,15 @@ genericSplitAt i sl@Slist{..}
       in (Slist l1 $ Size (fromIntegral i), Slist l2 s2)
 {-# INLINE genericSplitAt #-}
 
--- TODO: replace this with genericFindIndex?
+-- | @O(min i n)@
+-- The 'genericUnsafeAt' function is an overloaded version of 'unsafeAt', which
+-- accepts any 'Integral' value as the position. If the element on the given
+-- position does not exist it throws the exception at run-time.
 genericUnsafeAt :: Integral i => Slist a -> i -> a
 genericUnsafeAt _ i | i < 0 = errorWithoutStackTrace "Slist.genericIndex: negative argument."
 genericUnsafeAt (Slist l Infinity) i = L.genericIndex l i
-genericUnsafeAt (Slist l (Size s)) i
-    | i >= fromIntegral s = errorWithoutStackTrace "Slist.genericIndex: index too large."
+genericUnsafeAt (Slist l (Size n)) i
+    | i >= fromIntegral n = errorWithoutStackTrace "Slist.genericIndex: index too large."
     | otherwise = L.genericIndex l i
 {-# INLINE genericUnsafeAt #-}
 

--- a/src/Slist.hs
+++ b/src/Slist.hs
@@ -197,7 +197,7 @@ module Slist
        , genericTake
        , genericDrop
        , genericSplitAt
-       , genericIndex
+       , genericUnsafeAt
        , genericReplicate
        ) where
 

--- a/src/Slist.hs
+++ b/src/Slist.hs
@@ -1918,8 +1918,9 @@ genericLength = fromIntegral . length
 -- The 'genericTake' function is an overloaded version of 'take', which
 -- accepts any 'Integral' value as the number of elements to take.
 genericTake :: Integral i => i -> Slist a -> Slist a
-genericTake n Slist{..}
-    | n <= 0 = mempty
+genericTake i sl@Slist{..}
+    | Size i' >= sSize = sl
+    | i' <= 0 = mempty
     | otherwise = Slist
         { sList = L.genericTake n sList
         , sSize = min sSize (Size (fromIntegral n))

--- a/src/Slist.hs
+++ b/src/Slist.hs
@@ -197,6 +197,7 @@ module Slist
        , genericTake
        , genericDrop
        , genericSplitAt
+       , genericAt
        , genericUnsafeAt
        , genericReplicate
        ) where
@@ -1950,6 +1951,14 @@ genericSplitAt i sl@Slist{..}
           s2 = sSize - Size (fromIntegral i)
       in (Slist l1 $ Size (fromIntegral i), Slist l2 s2)
 {-# INLINE genericSplitAt #-}
+
+-- TODO: Add doc
+genericAt :: Integral i => i -> Slist a -> Maybe a
+genericAt n Slist{..}
+    | n' < 0 || Size n' >= sSize = Nothing
+    | otherwise = Just $ sList L.!! n'
+    where n' = fromIntegral n
+{-# INLINE genericAt #-}
 
 -- | @O(min i n)@
 -- The 'genericUnsafeAt' function is an overloaded version of 'unsafeAt', which

--- a/src/Slist.hs
+++ b/src/Slist.hs
@@ -1958,7 +1958,7 @@ genericUnsafeAt (Slist l Infinity) i = L.genericIndex l i
 genericUnsafeAt (Slist l (Size s)) i
     | i >= fromIntegral s = errorWithoutStackTrace "Slist.genericIndex: index too large."
     | otherwise = L.genericIndex l i
-{-# INLINE genericIndex #-}
+{-# INLINE genericUnsafeAt #-}
 
 -- | @O(n)@
 -- The 'genericReplicate' function is an overloaded version of 'replicate',

--- a/src/Slist.hs
+++ b/src/Slist.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE CPP          #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE ViewPatterns #-}
 
 {- |
 Copyright:  (c) 2019 vrom911
@@ -1938,14 +1939,13 @@ Slist {sList = "", sSize = Size 0}
 Slist {sList = [1,2,3,4], sSize = Size 4}
 -}
 genericTake :: Integral i => i -> Slist a -> Slist a
-genericTake i sl@Slist{..}
-    | Size i' >= sSize = sl
-    | i' <= 0 = mempty
+genericTake (fromIntegral -> i) sl@Slist{..}
+    | Size i >= sSize = sl
+    | i <= 0 = mempty
     | otherwise = Slist
         { sList = L.genericTake i sList
-        , sSize = min sSize (Size i')
+        , sSize = min sSize (Size i)
         }
-    where i' = fromIntegral i
 {-# INLINE genericTake #-}
 
 {- | @O(i) | i < n@ and @O(1) | otherwise@.
@@ -1968,14 +1968,13 @@ Slist {sList = [6..], sSize = 'Infinity'}
 
 -}
 genericDrop :: Integral i => i -> Slist a -> Slist a
-genericDrop i sl@Slist{..}
+genericDrop (fromIntegral -> i) sl@Slist{..}
     | i <= 0 = sl
-    | Size i' >= sSize = mempty
+    | Size i >= sSize = mempty
     | otherwise = Slist
         { sList = L.genericDrop i sList
-        , sSize = sSize - Size i'
+        , sSize = sSize - Size i
         }
-    where i' = fromIntegral i
 {-# INLINE genericDrop #-}
 
 {- | @O(i) | i < n@ and @O(1) | otherwise@.
@@ -1998,15 +1997,13 @@ accepts any 'Integral' value as the position at which to split.
 
 -}
 genericSplitAt :: Integral i => i -> Slist a -> (Slist a, Slist a)
-genericSplitAt i sl@Slist{..}
+genericSplitAt (fromIntegral -> i) sl@Slist{..}
     | i <= 0 = (mempty, sl)
-    | Size i' >= sSize = (sl, mempty)
+    | Size i >= sSize = (sl, mempty)
     | otherwise =
       let (l1, l2) = L.genericSplitAt i sList
-          s2 = sSize - Size i'
-      in (Slist l1 $ Size i', Slist l2 s2)
-    where
-      i' = fromIntegral i
+          s2 = sSize - Size i
+      in (Slist l1 $ Size i, Slist l2 s2)
 {-# INLINE genericSplitAt #-}
 
 {- | @O(i) | i < n@ and @O(1) | otherwise@.
@@ -2025,10 +2022,7 @@ Nothing
 Just 10
 -}
 genericAt :: Integral i => i -> Slist a -> Maybe a
-genericAt n Slist{..}
-    | n' < 0 || Size n' >= sSize = Nothing
-    | otherwise = Just $ sList L.!! n'
-    where n' = fromIntegral n
+genericAt = at . fromIntegral
 {-# INLINE genericAt #-}
 
 {- | @O(min i n)@.


### PR DESCRIPTION
Resolves #6  

`genericTake` differs syntactically from `take` for Slist. Personally, I liked this more. If it should be consistent, I can change it to fit the style of `take`.