### PR TITLE
[#16] Add `-Wmissing-deriving-strategies` to cabal ghc-options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,23 @@
 `slist` uses [PVP Versioning][1].
 The changelog is available [on GitHub][2].
 
-0.0.0
-=====
+## 0.1.0.0
+
+* [#13](https://github.com/vrom911/slist/issues/13):
+  Support GHC-8.8.1.
+* [#16](https://github.com/vrom911/slist/issues/16):
+  Use `DerivingStrategies`.
+* [#9](https://github.com/vrom911/slist/issues/9):
+  Implement `fromRange` function.
+  (by @zfnmxt)
+* [#6](https://github.com/vrom911/slist/issues/6):
+  Add generic function over the size and indices.
+  (by @waynee95)
+* Make `dropWhile` work better on infinite lists.
+  (by @chshersh)
+* Support GHC-8.6.5 instead os GHC-8.6.3.
+
+## 0.0.0
 
 * Initially created.
 

--- a/slist.cabal
+++ b/slist.cabal
@@ -1,6 +1,6 @@
 cabal-version:       3.0
 name:                slist
-version:             0.0.0
+version:             0.1.0.0
 synopsis:            Sized list
 description:         This package implements @Slist@ data structure that stores the size
                      of the list along with the list itself.
@@ -34,9 +34,13 @@ common common-options
                        -Widentities
                        -Wredundant-constraints
                        -fhide-source-paths
+  if impl(ghc >= 8.8.1)
+    ghc-options:       -Wmissing-deriving-strategies
+                       -Werror=missing-deriving-strategies
 
   default-extensions:  ConstraintKinds
                        DeriveGeneric
+                       DerivingStrategies
                        GeneralizedNewtypeDeriving
                        InstanceSigs
                        KindSignatures

--- a/src/Slist.hs
+++ b/src/Slist.hs
@@ -227,7 +227,7 @@ Size can be both finite or infinite, it is established using
 data Slist a = Slist
     { sList :: [a]
     , sSize :: Size
-    } deriving (Show, Read)
+    } deriving stock (Show, Read)
 
 {- | Equality of sized lists is checked more efficiently
 due to the fact that the check on the list sizes can be

--- a/src/Slist/Size.hs
+++ b/src/Slist/Size.hs
@@ -26,7 +26,7 @@ data Size
     = Size !Int
     -- | Infinite size.
     | Infinity
-    deriving (Show, Read, Eq, Ord)
+    deriving stock (Show, Read, Eq, Ord)
 
 {- | Efficient implementations of numeric operations with 'Size's.
 

--- a/test/Doctest.hs
+++ b/test/Doctest.hs
@@ -10,4 +10,5 @@ main = do
         $ "-XInstanceSigs"
         : "-XScopedTypeVariables"
         : "-XRecordWildCards"
+        : "-XDerivingStrategies"
         : sourceFiles


### PR DESCRIPTION
Resolves #16

Update CHANGELOG for the release