### PR TITLE
Monoid instance doesn't obey the concatenation law

### DIFF
--- a/slist.cabal
+++ b/slist.cabal
@@ -68,6 +68,8 @@ test-suite slist-test
   main-is:             Spec.hs
 
   build-depends:       slist
+                     , hedgehog
+                     , hedgehog-classes
 
   ghc-options:         -threaded
                        -rtsopts

--- a/src/Slist.hs
+++ b/src/Slist.hs
@@ -266,7 +266,7 @@ instance Monoid (Slist a) where
       where
         -- foldr :: (a -> ([a], Size) -> ([a], Size)) -> ([a], Size) -> [Slist a] -> ([a], Size)
         f :: Slist a -> ([a], Size) -> ([a], Size)
-        f (Slist l s) (xL, !xS) = (xL ++ l, s + xS)
+        f (Slist l s) (xL, !xS) = (l ++ xL, s + xS)
     {-# INLINE mconcat #-}
 
 instance Functor Slist where

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1,4 +1,27 @@
 module Main (main) where
 
+import Slist as  SL
+import           Hedgehog
+import           Hedgehog.Main (defaultMain)
+import           Hedgehog.Classes
+import qualified Hedgehog.Gen as Gen
+import qualified Hedgehog.Range as Range
+
 main :: IO ()
-main = putStrLn ("Test suite not yet implemented" :: String)
+main = defaultMain $
+  lawsCheck <$>
+    [ functorLaws genFiniteSlist
+    , applicativeLaws genFiniteSlist
+    , monadLaws genFiniteSlist
+    , foldableLaws genFiniteSlist
+    , traversableLaws genFiniteSlist
+    , alternativeLaws genFiniteSlist
+    , semigroupLaws (genFiniteSlist genInt)
+    , monoidLaws (genFiniteSlist genInt)
+    ]
+
+genInt :: Gen Int
+genInt = Gen.int (Range.linear 0 100)
+
+genFiniteSlist :: Gen a -> Gen (Slist a)
+genFiniteSlist gen = slist <$> Gen.list (Range.linear 0 100) gen


### PR DESCRIPTION
I've played around with [hedgehog-classes](http://hackage.haskell.org/package/hedgehog-classes) and your library in hope to solve #5. I guess I found a minor bug with `mconcat`: the monoid instance didn't obey the concatenation law (i.e. `mconcat ≡ foldr mappend mempty`). Consecutively, there were also problems with associativity and right identity monad laws; here's relevant part of test log:

```
Monoid: Concatenation   ✗ <interactive> failed 
    after 41 tests and 47 shrinks.
  
    forAll0 =
      [ Slist { sList = [ 0 ] , sSize = Size 1 }
      , Slist { sList = [ 1 ] , sSize = Size 1 }
      ]
  
    ━━━ Context ━━━
    When testing the Concatenation law(†), for the Monoid typeclass, the following test failed: 
    
    mconcat as ≡ foldr mappend mempty as, where
      as = [Slist {sList = [0], sSize = Size 1},Slist {sList = [1], sSize = Size 1}]
      mempty = Slist {sList = [], sSize = Size 0}
      
    
    The reduced test is: 
      Slist {sList = [1,0], sSize = Size 2} ≡ Slist {sList = [0,1], sSize = Size 2}
    
    The law in question: 
      (†) Concatenation Law: mconcat ≡ foldr mappend mempty
```

So `mconcat` concatenated lists in a wrong order, I guess. I flipped [just here](https://github.com/rszczers/slist/blob/073f2f586a316d8e4d447720192f0da4c352e7da/src/Slist.hs#L269) `(xL ++ l, s + xS)` to `(l ++ xL, s + xS)` and now all tests are passing fine :-)